### PR TITLE
Adjust to bigger bootloader

### DIFF
--- a/inc/localconf.h
+++ b/inc/localconf.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#define HSE_VALUE (*((uint32_t*)0x8003fcc))
+#define HSE_VALUE (*((uint32_t*)0x8007fcc))
 #define USE_FULL_ASSERT 1
 #define USB_MAX_PKT_SIZE 64
 #define BOOTLOADER_START_ADDR 0x08000000
-#define BOOTLOADER_END_ADDR 0x08004000
-#define APP_START_ADDR 0x08008000
+#define BOOTLOADER_END_ADDR 0x08008000
+#define APP_START_ADDR 0x08010000
 #define UF2_INFO_ADDR (const char*)(*(uint32_t*)(BOOTLOADER_END_ADDR - (16 * 4) + (4 * 4)))
 
 #define USB_DEFAULT_VID 0x0483 // STmicro

--- a/ld/stm32f4.ld
+++ b/ld/stm32f4.ld
@@ -1,7 +1,7 @@
 /* Linker script to configure memory regions. */
 MEMORY
 { 
-  FLASH (rx) : ORIGIN = 0x08008000, LENGTH = 512K
+  FLASH (rx) : ORIGIN = 0x08010000, LENGTH = 512K - 64K
   RAM (rwx)  : ORIGIN = 0x20000194, LENGTH = 96k - 0x194
 }
 

--- a/target-locked.json
+++ b/target-locked.json
@@ -32,7 +32,7 @@
     "generate_hex": true, 
     "libraries": [
         {
-            "branch": "78e2cc0c8124a1d7989432d552d042061957e0f3", 
+            "branch": "36dafe77219239c1397ece44ed37a7f6e6f50d5a", 
             "name": "codal-core", 
             "type": "git", 
             "url": "https://github.com/lancaster-university/codal-core"
@@ -47,6 +47,6 @@
     "linker_flags": "-Wl,--no-wchar-size-warning -Wl,--gc-sections -mcpu=cortex-m4 -mthumb", 
     "post_process": "python ./utils/uf2conv.py  -b 0x08008000 -o <OUTPUT_HEX_DESTINATION>/<OUTPUT_HEX_NAME>.uf2 -c <OUTPUT_BIN_LOCATION>", 
     "processor": "STM32F4", 
-    "snapshot_version": "v1.0.16-newusb.1", 
+    "snapshot_version": "v1.0.16-newusb.2", 
     "toolchain": "ARM_GCC"
 }

--- a/target-locked.json
+++ b/target-locked.json
@@ -32,13 +32,13 @@
     "generate_hex": true, 
     "libraries": [
         {
-            "branch": "839e9bcf745b58a03b02ed497b1ac6791c82149d", 
+            "branch": "3e7dc2b654f7271fbb51a56356df1894e6381114", 
             "name": "codal-core", 
             "type": "git", 
             "url": "https://github.com/lancaster-university/codal-core"
         }, 
         {
-            "branch": "1febd1a19c82b353f3d5e96a4a068c21d6a2da31", 
+            "branch": "5bb4ba75d405a6a0ed7c0e8b41186136ee4b7f19", 
             "name": "codal-stm32", 
             "type": "git", 
             "url": "https://github.com/lancaster-university/codal-stm32"
@@ -47,6 +47,6 @@
     "linker_flags": "-Wl,--no-wchar-size-warning -Wl,--gc-sections -mcpu=cortex-m4 -mthumb", 
     "post_process": "python ./utils/uf2conv.py  -b 0x08008000 -o <OUTPUT_HEX_DESTINATION>/<OUTPUT_HEX_NAME>.uf2 -c <OUTPUT_BIN_LOCATION>", 
     "processor": "STM32F4", 
-    "snapshot_version": "v1.0.16", 
+    "snapshot_version": "v1.0.16-newusb.0", 
     "toolchain": "ARM_GCC"
 }

--- a/target-locked.json
+++ b/target-locked.json
@@ -32,13 +32,13 @@
     "generate_hex": true, 
     "libraries": [
         {
-            "branch": "3e7dc2b654f7271fbb51a56356df1894e6381114", 
+            "branch": "78e2cc0c8124a1d7989432d552d042061957e0f3", 
             "name": "codal-core", 
             "type": "git", 
             "url": "https://github.com/lancaster-university/codal-core"
         }, 
         {
-            "branch": "5bb4ba75d405a6a0ed7c0e8b41186136ee4b7f19", 
+            "branch": "fc15db76a1898cc8625fe9de98c62c5d98c08ee8", 
             "name": "codal-stm32", 
             "type": "git", 
             "url": "https://github.com/lancaster-university/codal-stm32"
@@ -47,6 +47,6 @@
     "linker_flags": "-Wl,--no-wchar-size-warning -Wl,--gc-sections -mcpu=cortex-m4 -mthumb", 
     "post_process": "python ./utils/uf2conv.py  -b 0x08008000 -o <OUTPUT_HEX_DESTINATION>/<OUTPUT_HEX_NAME>.uf2 -c <OUTPUT_BIN_LOCATION>", 
     "processor": "STM32F4", 
-    "snapshot_version": "v1.0.16-newusb.0", 
+    "snapshot_version": "v1.0.16-newusb.1", 
     "toolchain": "ARM_GCC"
 }


### PR DESCRIPTION
This assumes the bootloader to be bigger (with write protection UI and WebUSB, also leaving some space for future JACDAC if needed). Attached are bootloaders - the two files will switch between the v1 (small) and v2 (big) bootloader.

[bl.zip](https://github.com/Microsoft/pxt-arcade/files/2734290/bl.zip)

CC @pelikhan @riknoll

